### PR TITLE
Add previewWill API integration for draft will previews

### DIFF
--- a/src/app/core/services/Wizard/will-data.service.ts
+++ b/src/app/core/services/Wizard/will-data.service.ts
@@ -25,6 +25,7 @@ const routes = {
     updateAssets: 'api/v1/assets',
     assetsDistribution: 'api/v1/distributions',
     updateAssetsDistribution: 'api/v1/distributions',
+    previewWill: 'api/v1/wills/preview-draft',
 }
 
 @Injectable({
@@ -282,6 +283,10 @@ export class WillDataService {
         .pipe()
         .subscribe();
 
+    }
+
+    previewWill() {
+        return this.apiService.getPreview<any>(this.baseURL + routes.previewWill)
     }
 
     getPersonalDetailsFromBE(): Observable<PersonalDetailsData> {

--- a/src/app/core/utils/api.service.ts
+++ b/src/app/core/utils/api.service.ts
@@ -117,6 +117,23 @@ export class ApiService {
                 catchError(this.handleRequestError)
             );
     };
+    getPreview = <T = any>(
+        route: string,
+        options?: any
+    ): Observable<T> => {
+        return this.http
+            .get<T>(
+                route,
+                options || {
+                    headers: new HttpHeaders(this.headers),
+                    responseType: 'arraybuffer'
+                 }
+            )
+            .pipe(
+                map((body: any) => body),
+                catchError(this.handleRequestError)
+            );
+    };
 
     // GET FILE
     getFile(url: string) {

--- a/src/app/features/wizard/review-and-download/review-and-download.component.ts
+++ b/src/app/features/wizard/review-and-download/review-and-download.component.ts
@@ -13,7 +13,6 @@ import { Router } from '@angular/router';
 import { WillDataService } from '../../../core/services/Wizard/will-data.service';
 import { WillData } from '../../../core/models/interfaces/will-data.interface';
 import { HeaderComponent } from '../widget/header/header.component';
-import { HttpClient } from '@angular/common/http';
 import { catchError, of } from 'rxjs';
 import { PdfViewerModule } from 'ng2-pdf-viewer';
 
@@ -58,7 +57,6 @@ export class ReviewAndDownloadComponent implements OnInit {
     constructor(
         private router: Router,
         private willDataService: WillDataService,
-        private http: HttpClient,
         @Inject(PLATFORM_ID) platformId: string,
         @Inject(APP_ID) appId: string
     ) {
@@ -81,9 +79,7 @@ export class ReviewAndDownloadComponent implements OnInit {
         this.pdfError = false;
         this.originalPdfData = null;
         this.pdfSrc = null;
-        console.log('Loading PDF from confirmed path: /doc/sample-will.pdf');
-        this.http
-            .get('/doc/sample-will.pdf', { responseType: 'arraybuffer' })
+        this.willDataService.previewWill()
             .pipe(
                 catchError((error) => {
                     console.error('Failed to load PDF:', error.message);


### PR DESCRIPTION
### Summary
- Introduced a `previewWill` method in `will-data.service` to fetch draft will previews.
- Integrated the `/api/v1/wills/preview-draft` endpoint.
- Updated the review-and-download component to utilize the new method.
- Added a generic `getPreview` utility in `api.service` to support the API call.
